### PR TITLE
HTML syntax highlighting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ main();
 The package contents are also available unzipped in the
 `package/` directory of the bucket, so an equivalent web example is:
 
-```
+```html
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
Just a small change to add HTML syntax highlighting to the `README.md`. Please decline if it makes your copybara sync harder.