### PR TITLE
fix: return error text for streaming api

### DIFF
--- a/src/_api_client.ts
+++ b/src/_api_client.ts
@@ -665,7 +665,7 @@ async function throwErrorIfNotOK(response: Response | undefined) {
     } else {
       errorBody = {
         error: {
-          message: 'exception parsing response',
+          message: await response.text(),
           code: response.status,
           status: response.statusText,
         },


### PR DESCRIPTION
Fixes #346

Return the error message text from the http response when using a streaming content type.
