### PR TITLE
fix: throw more dev-friendly errors

### DIFF
--- a/api-report/genai-node.api.md
+++ b/api-report/genai-node.api.md
@@ -25,6 +25,38 @@ export interface ActivityStart {
 }
 
 // @public
+export class ApiError extends Error {
+    constructor({ code, details, message, status }: ApiErrorResponse['error'], stackTrace?: string);
+    // (undocumented)
+    code: ApiErrorResponse['error']['code'];
+    // (undocumented)
+    details: ApiErrorResponse['error']['details'];
+    // (undocumented)
+    name: string;
+    // (undocumented)
+    status: ApiErrorResponse['error']['status'];
+}
+
+// @public (undocumented)
+export type ApiErrorResponse = {
+    error: {
+        code: number;
+        message: string;
+        status?: string;
+        details?: Array<{
+            "@type": string;
+            reason?: string;
+            domain?: string;
+            metadata?: {
+                service?: string;
+            };
+            locale?: string;
+            message?: string;
+        }>;
+    };
+};
+
+// @public
 export interface AudioTranscriptionConfig {
 }
 
@@ -133,6 +165,11 @@ export interface Citation {
 // @public
 export interface CitationMetadata {
     citations?: Citation[];
+}
+
+// @public
+export class ClientError extends ApiError {
+    constructor(response: ApiErrorResponse['error'], stackTrace?: string);
 }
 
 // @public
@@ -1598,6 +1635,11 @@ export interface Segment {
 export interface SendMessageParameters {
     config?: GenerateContentConfig;
     message: PartListUnion;
+}
+
+// @public
+export class ServerError extends ApiError {
+    constructor(response: ApiErrorResponse['error'], stackTrace?: string);
 }
 
 // @public

--- a/api-report/genai-web.api.md
+++ b/api-report/genai-web.api.md
@@ -25,6 +25,38 @@ export interface ActivityStart {
 }
 
 // @public
+export class ApiError extends Error {
+    constructor({ code, details, message, status }: ApiErrorResponse['error'], stackTrace?: string);
+    // (undocumented)
+    code: ApiErrorResponse['error']['code'];
+    // (undocumented)
+    details: ApiErrorResponse['error']['details'];
+    // (undocumented)
+    name: string;
+    // (undocumented)
+    status: ApiErrorResponse['error']['status'];
+}
+
+// @public (undocumented)
+export type ApiErrorResponse = {
+    error: {
+        code: number;
+        message: string;
+        status?: string;
+        details?: Array<{
+            "@type": string;
+            reason?: string;
+            domain?: string;
+            metadata?: {
+                service?: string;
+            };
+            locale?: string;
+            message?: string;
+        }>;
+    };
+};
+
+// @public
 export interface AudioTranscriptionConfig {
 }
 
@@ -133,6 +165,11 @@ export interface Citation {
 // @public
 export interface CitationMetadata {
     citations?: Citation[];
+}
+
+// @public
+export class ClientError extends ApiError {
+    constructor(response: ApiErrorResponse['error'], stackTrace?: string);
 }
 
 // @public
@@ -1598,6 +1635,11 @@ export interface Segment {
 export interface SendMessageParameters {
     config?: GenerateContentConfig;
     message: PartListUnion;
+}
+
+// @public
+export class ServerError extends ApiError {
+    constructor(response: ApiErrorResponse['error'], stackTrace?: string);
 }
 
 // @public

--- a/api-report/genai.api.md
+++ b/api-report/genai.api.md
@@ -25,6 +25,38 @@ export interface ActivityStart {
 }
 
 // @public
+export class ApiError extends Error {
+    constructor({ code, details, message, status }: ApiErrorResponse['error'], stackTrace?: string);
+    // (undocumented)
+    code: ApiErrorResponse['error']['code'];
+    // (undocumented)
+    details: ApiErrorResponse['error']['details'];
+    // (undocumented)
+    name: string;
+    // (undocumented)
+    status: ApiErrorResponse['error']['status'];
+}
+
+// @public (undocumented)
+export type ApiErrorResponse = {
+    error: {
+        code: number;
+        message: string;
+        status?: string;
+        details?: Array<{
+            "@type": string;
+            reason?: string;
+            domain?: string;
+            metadata?: {
+                service?: string;
+            };
+            locale?: string;
+            message?: string;
+        }>;
+    };
+};
+
+// @public
 export interface AudioTranscriptionConfig {
 }
 
@@ -133,6 +165,11 @@ export interface Citation {
 // @public
 export interface CitationMetadata {
     citations?: Citation[];
+}
+
+// @public
+export class ClientError extends ApiError {
+    constructor(response: ApiErrorResponse['error'], stackTrace?: string);
 }
 
 // @public
@@ -1598,6 +1635,11 @@ export interface Segment {
 export interface SendMessageParameters {
     config?: GenerateContentConfig;
     message: PartListUnion;
+}
+
+// @public
+export class ServerError extends ApiError {
+    constructor(response: ApiErrorResponse['error'], stackTrace?: string);
 }
 
 // @public

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,46 @@
+import { ApiErrorResponse } from "./types";
+
+/**
+ * Base interface for the API error response. 
+ */
+export class ApiError extends Error {
+  code: ApiErrorResponse['error']['code'];
+  status: ApiErrorResponse['error']['status'];
+  details: ApiErrorResponse['error']['details'];
+  name: string = 'ApiError';
+
+  constructor({code, details, message, status}: ApiErrorResponse['error'], stackTrace?: string) {
+    super(message, {cause: stackTrace});
+    this.code = code;
+    this.status = status;
+    this.details = details;
+  }
+}
+
+/**
+ * Client errors raised by the GenAI API.
+ */
+export class ClientError extends ApiError {
+  constructor(response: ApiErrorResponse['error'], stackTrace?: string) {
+    if (stackTrace) {
+      super(response, stackTrace);
+    } else {
+      super(response, new Error().stack);
+    }
+    this.name = 'ClientError';
+  }
+}
+
+/**
+ * Server errors raised by the GenAI API.
+ */
+export class ServerError extends ApiError {
+  constructor(response: ApiErrorResponse['error'], stackTrace?: string) {
+    if (stackTrace) {
+      super(response, stackTrace);
+    } else {
+      super(response, new Error().stack);
+    }
+    this.name = 'ServerError';
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,4 @@ export {Models} from './models';
 export {Operations} from './operations';
 export {PagedItem, Pager} from './pagers';
 export * from './types';
+export * from './errors'

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -14,3 +14,4 @@ export {Operations} from '../operations';
 export {PagedItem, Pager} from '../pagers';
 export * from '../types';
 export * from './node_client';
+export * from '../errors';

--- a/src/types.ts
+++ b/src/types.ts
@@ -2917,3 +2917,21 @@ export type SchemaUnion = Schema;
 export type SpeechConfigUnion = SpeechConfig | string;
 
 export type ToolListUnion = Tool[];
+
+export type ApiErrorResponse = {
+  error: {
+    code: number;
+    message: string;
+    status?: string;
+    details?: Array<{
+      "@type": string;
+      reason?: string;
+      domain?: string;
+      metadata?: {
+        service?: string;
+      };
+      locale?: string;
+      message?: string;
+    }>;
+  };
+}

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -14,3 +14,4 @@ export {Operations} from '../operations';
 export {PagedItem, Pager} from '../pagers';
 export * from '../types';
 export * from './web_client';
+export * from '../errors';


### PR DESCRIPTION
Throw errors that are representations of the error json response sent from google's endpoint instead of an unparsable string and expose them to devs.
In style of the python-genai:
https://github.com/googleapis/python-genai/blob/b9d3be1e87a3e4260c16a3c36e0c728b330f831a/google/genai/errors.py#L51

That'd solve the https://github.com/googleapis/js-genai/issues/455 I guess