### PR TITLE
minor syntax errors in documentation

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -777,11 +777,12 @@ export class Models extends BaseModule {
    *
    * @example
    * ```ts
-   * const operation = await ai.models.generateVideos({
+   * let operation = await ai.models.generateVideos({
    *  model: 'veo-2.0-generate-001',
    *  prompt: 'A neon hologram of a cat driving at top speed',
    *  config: {
    *    numberOfVideos: 1
+   *  }
    * });
    *
    * while (!operation.done) {


### PR DESCRIPTION
[Documentation for `generateVideos`](https://googleapis.github.io/js-genai/main/classes/models.Models.html#generatevideos) has 2 syntax errors. 
- It reassigns a `const` and 
- it doesn't close an object.

