### PR TITLE
refactor: Normalize empty env strings to undefined in getEnv

### DIFF
--- a/src/node/node_client.ts
+++ b/src/node/node_client.ts
@@ -167,7 +167,8 @@ export class GoogleGenAI {
 }
 
 function getEnv(env: string): string | undefined {
-  return process?.env?.[env]?.trim() ?? undefined;
+  const value = process?.env?.[env]?.trim();
+  return value === '' ? undefined : value;
 }
 
 function getBooleanEnv(env: string): boolean {


### PR DESCRIPTION
This PR modifies the `getEnv` utility to correctly handle empty string values for environment variables like `GOOGLE_API_KEY`.

Currently, if `GOOGLE_API_KEY` is set to an empty string (e.g., as a placeholder), `NodeAuth` initialization incorrectly uses this empty string as a valid API key. This causes `NodeAuth` to ignore `googleAuthOptions`, which is problematic when intending to authenticate using project/location for Vertex AI (where no API key should be used).

The `getEnv` function now returns `undefined` if an environment variable's value is an empty string (after trimming). This ensures that an empty `GOOGLE_API_KEY` is treated as "not provided," allowing `NodeAuth` to correctly fall back to using `googleAuthOptions`.