### PR TITLE
chore: Add example of chats endpoint usage with history and system instruction

### DIFF
--- a/sdk-samples/chat_afc.ts
+++ b/sdk-samples/chat_afc.ts
@@ -41,6 +41,27 @@ async function chatAutofcSample(ai: GoogleGenAI) {
   });
 }
 
+async function chatWithHistoryAndSystemInstructionSample(ai: GoogleGenAI) {
+  const conversationHistory = [
+    {role: 'user', parts: [{text: 'Hello!'}]},
+    {role: 'model', parts: [{text: 'Hi, how can I help you?'}]},
+  ];
+
+  const personaDescription = 'You are a helpful assistant.';
+
+  const chat = await ai.chats.create({
+    model: 'gemini-2.0-flash',
+    history: conversationHistory,
+    config: {
+      systemInstruction: personaDescription,
+    },
+  });
+
+  await chat.sendMessage({
+    message: {text: 'Multiply 5 by 6.'},
+  });
+}
+
 async function spinUpWeatherServer(): Promise<Client> {
   const server = new McpServer({
     name: 'reporter',
@@ -122,6 +143,7 @@ async function main() {
   }
 
   chatAutofcSample(ai);
+  chatWithHistoryAndSystemInstructionSample(ai);
 }
 
 main();

--- a/src/chats.ts
+++ b/src/chats.ts
@@ -124,10 +124,15 @@ export class Chats {
    * @example
    * ```ts
    * const chat = ai.chats.create({
-   *   model: 'gemini-2.0-flash'
+   *   model: 'gemini-2.0-flash',
+   *   history: [
+   *     {role: 'user', parts: [{text: 'Hello!'}]},
+   *     {role: 'model', parts: [{text: 'Hi, how can I help you?'}]},
+   *   ],
    *   config: {
    *     temperature: 0.5,
    *     maxOutputTokens: 1024,
+   *     systemInstruction: 'You are a helpful assistant.',
    *   }
    * });
    * ```


### PR DESCRIPTION
I noticed that this particular usage was not documented for the chats API.

Therefore I would propose to include this example in the sdk-samples and src/chats.ts.

This would enable users to easily find how to add custom system instructions and how to restart chat with history.