### PR TITLE
fix: Ensure proper assignment of apiKey, project and location for node client

### DIFF
--- a/src/node/node_client.ts
+++ b/src/node/node_client.ts
@@ -94,9 +94,9 @@ export class GoogleGenAI {
     const envProject = getEnv('GOOGLE_CLOUD_PROJECT');
     const envLocation = getEnv('GOOGLE_CLOUD_LOCATION');
 
-    this.apiKey = options.apiKey ?? envApiKey;
-    this.project = options.project ?? envProject;
-    this.location = options.location ?? envLocation;
+    this.apiKey = (options.apiKey ?? envApiKey) || undefined;
+    this.project = (options.project ?? envProject) || undefined;
+    this.location = (options.location ?? envLocation) || undefined;
 
     // Handle when to use Vertex AI in express mode (api key)
     if (options.vertexai) {


### PR DESCRIPTION
This PR updates the `GoogleGenAI` constructor to correctly handle empty string values for environment variables like `GOOGLE_API_KEY`.

Previously, if `GOOGLE_API_KEY` was set to an empty string in the environment, even when `options` specified `project` and `location` for Vertex AI, `this.apiKey` would be incorrectly assigned an empty string. This prevented the client from properly authenticating with Vertex AI using `project` and `location`, as an empty API key was mistakenly treated as a valid (but non-functional) key.

The fix modifies how `this.apiKey`, `this.project`, and `this.location` are assigned in the constructor. For instance, `this.apiKey` now uses `(options.apiKey ?? envApiKey) || undefined`. This ensures that if the resolved value from options or the environment is an empty string, the corresponding instance property (e.g., `this.apiKey`) becomes `undefined`.

This change ensures an empty `GOOGLE_API_KEY` is treated as "not provided," allowing the client to correctly fall back to using `project` and `location` for Vertex AI authentication when intended.