### PR TITLE
fix(live): Add enableAffectiveDialog to GenerationConfig

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3334,6 +3334,8 @@ export declare interface GenerationConfigThinkingConfig {
 
 /** Generation config. */
 export declare interface GenerationConfig {
+  /** If enabled, the model will detect emotions and adapt its responses accordingly. */
+  enableAffectiveDialog?: boolean;
   /** Optional. Config for model selection. */
   modelSelectionConfig?: ModelSelectionConfig;
   /** Optional. If enabled, audio timestamp will be included in the request to the model. */
@@ -5451,7 +5453,7 @@ export declare interface ProactivityConfig {
 
 /** Message contains configuration that will apply for the duration of the streaming session. */
 export declare interface LiveClientSetup {
-  /** 
+  /**
       The fully qualified name of the publisher model or tuned model endpoint to
       use.
        */
@@ -5547,7 +5549,7 @@ export declare interface LiveClientRealtimeInput {
   mediaChunks?: Blob[];
   /** The realtime audio input stream. */
   audio?: Blob;
-  /** 
+  /**
 Indicates that the audio stream has ended, e.g. because the microphone was
 turned off.
 
@@ -5588,7 +5590,7 @@ export declare interface LiveSendRealtimeInputParameters {
   media?: BlobImageUnion;
   /** The realtime audio input stream. */
   audio?: Blob;
-  /** 
+  /**
 Indicates that the audio stream has ended, e.g. because the microphone was
 turned off.
 


### PR DESCRIPTION
This has been only added to `LiveConnectConfig`, however it's also a valid property in `GenerationConfig` when using a client setup message.