### PR TITLE
Fix: #764 multi-byte character can be corrupted in processStreamResponse

### DIFF
--- a/src/_api_client.ts
+++ b/src/_api_client.ts
@@ -528,7 +528,7 @@ export class ApiClient {
           }
           break;
         }
-        const chunkString = decoder.decode(value);
+        const chunkString = decoder.decode(value, {stream: true});
 
         // Parse and throw an error if the chunk contains an error.
         try {


### PR DESCRIPTION
To fix #764, I added `{stream:true}` option to call TextDecoder.decode in ApiClient.processStreamResponse. Added an unit test case of the method with responses chunked at the middle of multi-byte character.
