### PR TITLE
fix: empty env vars should be treated as undefined

### DIFF
--- a/src/node/node_client.ts
+++ b/src/node/node_client.ts
@@ -182,7 +182,8 @@ export class GoogleGenAI {
 }
 
 function getEnv(env: string): string | undefined {
-  return process?.env?.[env]?.trim() ?? undefined;
+  const value = process?.env?.[env]?.trim();
+  return value || undefined;
 }
 
 function getBooleanEnv(env: string): boolean {

--- a/test/unit/node/client_test.ts
+++ b/test/unit/node/client_test.ts
@@ -57,6 +57,13 @@ describe('Client', () => {
     );
   });
 
+  it('should not set apiKey if both GEMINI_API_KEY and GOOGLE_API_KEY are set to empty string', () => {
+    process.env['GOOGLE_API_KEY'] = '';
+    process.env['GEMINI_API_KEY'] = '';
+    const client = new GoogleGenAI({});
+    expect(client['apiKey']).toBe(undefined);
+  });
+
   it('should set vertexai from environment', () => {
     process.env['GOOGLE_GENAI_USE_VERTEXAI'] = 'false';
     let client = new GoogleGenAI({});
@@ -73,10 +80,22 @@ describe('Client', () => {
     expect(client['project']).toBe('test_project');
   });
 
+  it('should not set project if GOOGLE_CLOUD_PROJECT is set to an empty string', () => {
+    process.env['GOOGLE_CLOUD_PROJECT'] = '';
+    const client = new GoogleGenAI({});
+    expect(client['project']).toBe(undefined);
+  });
+
   it('should set location from environment', () => {
     process.env['GOOGLE_CLOUD_LOCATION'] = 'test_location';
     const client = new GoogleGenAI({});
     expect(client['location']).toBe('test_location');
+  });
+
+  it('should not set location if GOOGLE_CLOUD_LOCATION is set to an empty string', () => {
+    process.env['GOOGLE_CLOUD_LOCATION'] = '';
+    const client = new GoogleGenAI({});
+    expect(client['location']).toBe(undefined);
   });
 
   it('should prioritize constructor options over environment variables', () => {


### PR DESCRIPTION
If the `GEMINI_API_KEY` env var is set to empty and Vertex AI env vars are set, then the `GoogleGenAI` client is initialized with `{"apiKey":"","vertexai":true}` which fails to use Vertex AI. 
This is causing failures for Github Action runtimes in https://github.com/google-github-actions/run-gemini-cli. 

This change ensures that empty environment variables are handled as undefined.