### PR TITLE
ApiClient - Don't throw away error context.

### DIFF
--- a/src/_api_client.ts
+++ b/src/_api_client.ts
@@ -597,7 +597,7 @@ export class ApiClient {
     requestInit: RequestInit,
   ): Promise<Response> {
     return fetch(url, requestInit).catch((e) => {
-      throw new Error(`exception ${e} sending request`);
+      throw new Error(`exception ${e} sending request`, { cause: e });
     });
   }
 


### PR DESCRIPTION
Quite regularly I'm facing errors that look like this while feeding large documents into Gemini Pro 2.5:

```
exception TypeError: fetch failed sending request
    at /workspace/node_modules/@google/genai/dist/node/index.cjs:14828:19
    at async Models.generateContent (/workspace/node_modules/@google/genai/dist/node/index.cjs:16000:24)
    (...application-specific backtrace lines omitted...)
```

I'm not sure why this code is catching the error only to re-throw it, but if you're going to do that, it's helpful to preserve the original Error under the `cause` field so I can more easily detect these failures and look into what the true error is (my guess is a timeout of some kind, but who knows)