### PR TITLE
fix: prevent mutation of original tool object in tTool

### DIFF
--- a/src/_transformers.ts
+++ b/src/_transformers.ts
@@ -467,8 +467,11 @@ export function tLiveSpeechConfig(
 }
 
 export function tTool(tool: types.Tool): types.Tool {
-  if (tool.functionDeclarations) {
-    for (const functionDeclaration of tool.functionDeclarations) {
+  // Create a deep copy to avoid mutating the original object.
+  const clonedTool = structuredClone(tool);
+  
+  if (clonedTool.functionDeclarations) {
+    for (const functionDeclaration of clonedTool.functionDeclarations) {
       if (functionDeclaration.parameters) {
         if (!Object.keys(functionDeclaration.parameters).includes('$schema')) {
           functionDeclaration.parameters = processJsonSchema(
@@ -497,7 +500,7 @@ export function tTool(tool: types.Tool): types.Tool {
       }
     }
   }
-  return tool;
+  return clonedTool;
 }
 
 export function tTools(tools: types.ToolListUnion | unknown): types.Tool[] {


### PR DESCRIPTION
The `tTool` function was directly mutating the input `tool` object, which causes issues in multi-provider scenarios.

When using this SDK alongside other AI providers (OpenAI, Claude, etc.) in the same project, developers often define tool schemas once and reuse them across multiple providers. However, `tTool` mutates the original object by:
- Converting type fields to uppercase (e.g., `"string"` → `"STRING"`)

This mutation breaks compatibility with other providers that expect the original format, forcing developers to manually deep-clone objects before passing them to this SDK.

Use `structuredClone` to create a deep copy of the input object before applying transformations, ensuring the original object remains unchanged and reusable across different providers.
