### PR TITLE
add resizeMode parameter to GenerateVideosConfig

### DIFF
--- a/api-report/genai-node.api.md
+++ b/api-report/genai-node.api.md
@@ -1389,6 +1389,7 @@ export interface GenerateVideosConfig {
     personGeneration?: string;
     pubsubTopic?: string;
     referenceImages?: VideoGenerationReferenceImage[];
+    resizeMode?: string;
     resolution?: string;
     seed?: number;
 }

--- a/api-report/genai-web.api.md
+++ b/api-report/genai-web.api.md
@@ -1389,6 +1389,7 @@ export interface GenerateVideosConfig {
     personGeneration?: string;
     pubsubTopic?: string;
     referenceImages?: VideoGenerationReferenceImage[];
+    resizeMode?: string;
     resolution?: string;
     seed?: number;
 }

--- a/api-report/genai.api.md
+++ b/api-report/genai.api.md
@@ -1389,6 +1389,7 @@ export interface GenerateVideosConfig {
     personGeneration?: string;
     pubsubTopic?: string;
     referenceImages?: VideoGenerationReferenceImage[];
+    resizeMode?: string;
     resolution?: string;
     seed?: number;
 }

--- a/src/converters/_models_converters.ts
+++ b/src/converters/_models_converters.ts
@@ -2321,6 +2321,15 @@ export function generateVideosConfigToMldev(
     );
   }
 
+  const fromResizeMode = common.getValueByPath(fromObject, ['resizeMode']);
+  if (parentObject !== undefined && fromResizeMode != null) {
+    common.setValueByPath(
+      parentObject,
+      ['parameters', 'resizeMode'],
+      fromResizeMode,
+    );
+  }
+
   const fromPersonGeneration = common.getValueByPath(fromObject, [
     'personGeneration',
   ]);
@@ -2463,6 +2472,15 @@ export function generateVideosConfigToVertex(
       parentObject,
       ['parameters', 'resolution'],
       fromResolution,
+    );
+  }
+
+  const fromResizeMode = common.getValueByPath(fromObject, ['resizeMode']);
+  if (parentObject !== undefined && fromResizeMode != null) {
+    common.setValueByPath(
+      parentObject,
+      ['parameters', 'resizeMode'],
+      fromResizeMode,
     );
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3832,6 +3832,9 @@ export declare interface GenerateVideosConfig {
   /** The resolution for the generated video. 720p and 1080p are
       supported. */
   resolution?: string;
+  /** The resize mode for the generated video. Supported values are: pad, crop.
+      Determines how the input image/video is resized to match the output aspect ratio. */
+  resizeMode?: string;
   /** Whether allow to generate person videos, and restrict to specific
       ages. Supported values are: dont_allow, allow_adult. */
   personGeneration?: string;


### PR DESCRIPTION
   ## Description
   
   Adds support for the `resizeMode` parameter in the `GenerateVideosConfig` interface.
   
   The HTTP API supports the `resizeMode` parameter ('pad' or 'crop'), but it was not 
   available in the TypeScript SDK. This change adds the parameter to the interface and 
   converter functions for both Vertex AI and Gemini API endpoints.
   
   Fixes #1089
   
   ## Changes Made
   
   - Added `resizeMode?: string` property to `GenerateVideosConfig` interface in `src/types.ts`
   - Added parameter mapping in `generateVideosConfigToVertex()` converter
   - Added parameter mapping in `generateVideosConfigToMldev()` converter
   - Updated API reports for genai, genai-node, and genai-web
   
   ## Testing
   
   - ✅ Build successful (`npm run build`)
   - ✅ Linting passed (`npm run lint`)
   - ✅ API reports generated correctly