### PR TITLE
fix: send displayName/mimeType in uploadToFileSearchStore body (fileSearchStores)

### DIFF
--- a/src/_api_client.ts
+++ b/src/_api_client.ts
@@ -730,6 +730,12 @@ export class ApiClient {
     if (config != null) {
       uploadToFileSearchStoreConfigToMldev(config, body);
     }
+    if (config?.displayName){
+      body['displayName'] = config.displayName;
+    }
+    if (config?.mimeType){
+      body['mimeType'] = config.mimeType;
+    }
     const uploadUrl = await this.fetchUploadUrl(
       path,
       sizeBytes,


### PR DESCRIPTION
## Problem

When uploading a document to a File Search store via `uploadToFileSearchStore` using a `Blob`, the SDK does not send `displayName` (and related metadata) in the request body used to obtain the upload URL. As a result, created documents can end up with undefined and downstream retrieval/citations lose the friendly name.

## Current Behavior

- `config.displayName` is accepted by the SDK call, but the value is not forwarded into the `uploadToFileSearchStore` request body.
- Documents created in File Search may show `displayName: (no display name)` even though the caller set it.
- This makes it hard to show friendly source names in RAG citations / grounding chunks.

## Expected Behavior

- `displayName` provided in `config` should be persisted as the created document’s display name.
- `mimeType` provided in `config` should be forwarded consistently as part of the request metadata.
- SDK behavior should match the underlying File Search Stores API which supports these fields in the request body.

## Fix

- Add `displayName` and `mimeType` to the JSON request body passed to the `uploadToFileSearchStore` endpoint when generating the upload URL.
- This aligns the SDK with the File Search Stores API request schema (which explicitly allows `displayName` and `mimeType`). 
