### PR TITLE
fix: uploadFileToFileSearchStore missing displayName

### DIFF
--- a/src/_api_client.ts
+++ b/src/_api_client.ts
@@ -761,7 +761,7 @@ export class ApiClient implements GeminiNextGenAPIClientAdapter {
       );
     }
     const path = `upload/v1beta/${fileSearchStoreName}:uploadToFileSearchStore`;
-    const fileName = this.getFileName(file);
+    const fileName = config?.displayName ?? this.getFileName(file);
     const body: Record<string, unknown> = {};
     if (config != null) {
       uploadToFileSearchStoreConfigToMldev(config, body);


### PR DESCRIPTION
## Problem

Blob uploads are missing document names. As a result, when querying the FileSearchStore via the Gemini tool, `GroundingMetadata` doesn't include the document name, since it doesn't exist -- which means citations can't back reference the document they originated from.

### Reason

`uploadFileToFileSearchStore` accepts a `displayName` per `UploadToFileSearchStoreConfig`

https://github.com/googleapis/js-genai/blob/86836943a9e3c4f7b7068528ef715e015dd2e675/src/types.ts#L4989-L4990

However, it is ignored, and instead the file name is determined by `getFileName(file)`, basing the name off of the file path
https://github.com/googleapis/js-genai/blob/86836943a9e3c4f7b7068528ef715e015dd2e675/src/_api_client.ts#L673-L680

Furthermore, when providing a `Blob` as the file, there is no file path, so the document is left unnamed, even if `displayName` is provided.


## Solution

When `config.displayName` is provided, use that. Otherwise, fallback to existing behavior via `getFileName(name)`


## Reproducible Steps

1. Add a file from a `Blob` to a FileSearchStore
```tsx
client.fileSearchStores.uploadToFileSearchStore({
  fileSearchStoreName: 'fileSearchStores/X',
  file: new Blob(['I will not have a displayName'], { mimeType: 'text/plain' }),
  config: {
    displayName: 'This name will not appear',
    mimeType: 'text/plain'
  }
});
```

2. Query the document, it will come back without a `displayName`
```tsx
{
  "documents": [
    {
        "name": "fileSearchStores/teststore-h96irg23frs2/documents/testfiletxt-kjvz41r4ubzb",
        "updateTime": "2025-12-18T21:09:10.504760Z",
        "createTime": "2025-12-18T21:09:09.758171Z",
        "state": "STATE_ACTIVE",
        "sizeBytes": "11",
        "mimeType": "text/plain"
    }
  ]
}
```