### PR TITLE
fix: handle plain object from google-auth-library getRequestHeaders

### DIFF
--- a/src/node/_node_auth.ts
+++ b/src/node/_node_auth.ts
@@ -76,7 +76,14 @@ export class NodeAuth implements Auth {
       );
     }
     const authHeaders = await this.googleAuth.getRequestHeaders(url);
-    for (const [key, value] of authHeaders) {
+    // google-auth-library may return either an iterable (Map/Headers) or a plain
+    // object depending on the auth client used. Handle both cases.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const entries =
+      typeof (authHeaders as any)[Symbol.iterator] === 'function'
+        ? authHeaders
+        : Object.entries(authHeaders);
+    for (const [key, value] of entries) {
       if (headers.get(key) !== null) {
         continue;
       }

--- a/test/unit/node/node_auth_test.ts
+++ b/test/unit/node/node_auth_test.ts
@@ -54,6 +54,25 @@ describe('addAuthHeaders', () => {
     expect(googleAuthMock.getRequestHeaders).toHaveBeenCalledWith(mockUrl);
   });
 
+  it('should add auth headers when google-auth-library returns a plain object', async () => {
+    const nodeAuth = new NodeAuth({});
+    (nodeAuth as unknown as NodeAuthWithGoogleAuth).googleAuth = googleAuthMock; // Inject the mock
+    // google-auth-library actually returns a plain object { [index: string]: string }
+    const mockHeaders = {
+      Authorization: 'Bearer test-token',
+      'x-goog-user-project': 'test-project',
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    googleAuthMock.getRequestHeaders.and.resolveTo(mockHeaders as any);
+    const headers = new Headers();
+
+    await nodeAuth.addAuthHeaders(headers, mockUrl);
+
+    expect(headers.get('Authorization')).toBe('Bearer test-token');
+    expect(headers.get('x-goog-user-project')).toBe('test-project');
+    expect(googleAuthMock.getRequestHeaders).toHaveBeenCalledWith(mockUrl);
+  });
+
   it('should not add an Authorization header if it already exists', async () => {
     const nodeAuth = new NodeAuth({});
     (nodeAuth as unknown as NodeAuthWithGoogleAuth).googleAuth = googleAuthMock; // Inject the mock


### PR DESCRIPTION
## Summary
- Fix `TypeError: authHeaders is not iterable` when using Vertex AI with `googleAuthOptions.authClient`
- Add test case for plain object headers from `google-auth-library`

## Root Cause
`google-auth-library`'s `GoogleAuth.getRequestHeaders()` returns a plain object `{ [index: string]: string }`, not an
iterable like `Map` or Web `Headers`. The code in `_node_auth.ts` used `for...of` directly on the result, which fails for
plain objects.

## Fix
Check if `authHeaders` has `Symbol.iterator` before iterating. If not iterable, use `Object.entries()` to convert the plain
object to an iterable. This matches the existing pattern in `node_files.ts`.