### PR TITLE
fix: drain intermediate upload responses

### DIFF
--- a/src/cross/_cross_uploader.ts
+++ b/src/cross/_cross_uploader.ts
@@ -20,6 +20,16 @@ export const INITIAL_RETRY_DELAY_MS = 1000;
 export const DELAY_MULTIPLIER = 2;
 export const X_GOOG_UPLOAD_STATUS_HEADER_FIELD = 'x-goog-upload-status';
 
+export async function discardResponseBody(
+  response: HttpResponse | undefined,
+): Promise<void> {
+  const body = response?.responseInternal?.body;
+  if (!body || response?.responseInternal?.bodyUsed) {
+    return;
+  }
+  await body.cancel();
+}
+
 export class CrossUploader implements Uploader {
   async upload(
     file: string | Blob,
@@ -160,6 +170,7 @@ async function uploadBlobInternal(
       if (response?.headers?.[X_GOOG_UPLOAD_STATUS_HEADER_FIELD]) {
         break;
       }
+      await discardResponseBody(response);
       retryCount++;
       await sleep(currentDelayMs);
       currentDelayMs = currentDelayMs * DELAY_MULTIPLIER;
@@ -177,6 +188,7 @@ async function uploadBlobInternal(
         'All content has been uploaded, but the upload status is not finalized.',
       );
     }
+    await discardResponseBody(response);
   }
 
   return response;

--- a/src/node/_node_uploader.ts
+++ b/src/node/_node_uploader.ts
@@ -15,6 +15,7 @@ import {
   MAX_CHUNK_SIZE,
   MAX_RETRY_COUNT,
   X_GOOG_UPLOAD_STATUS_HEADER_FIELD,
+  discardResponseBody,
   getBlobStat,
   sleep,
   uploadBlob,
@@ -301,6 +302,7 @@ export class NodeUploader implements Uploader {
           if (response?.headers?.[X_GOOG_UPLOAD_STATUS_HEADER_FIELD]) {
             break;
           }
+          await discardResponseBody(response);
           retryCount++;
           await sleep(currentDelayMs);
           currentDelayMs = currentDelayMs * DELAY_MULTIPLIER;
@@ -318,6 +320,7 @@ export class NodeUploader implements Uploader {
             'All content has been uploaded, but the upload status is not finalized.',
           );
         }
+        await discardResponseBody(response);
       }
       return response;
     } finally {

--- a/test/unit/file_test.ts
+++ b/test/unit/file_test.ts
@@ -100,12 +100,13 @@ describe('File', () => {
       },
       url: 'some-url',
     };
-    const mockResponse = new Response(
-      JSON.stringify({
-        data: 'data1',
-      }),
-      uploadOkOptions,
-    );
+    const createUploadActiveResponse = () =>
+      new Response(
+        JSON.stringify({
+          data: 'data1',
+        }),
+        uploadOkOptions,
+      );
     const fileSize = TEST_FILE_SIZE;
     describe('Node_client', () => {
       it('It should upload the file from a string path.', async () => {
@@ -117,9 +118,12 @@ describe('File', () => {
         const mockResponses = [
           Promise.resolve(new Response('', createUrlOkoptions)),
         ];
+        const activeResponses = [];
 
         for (let i = 0; i < numRequests - 1; i++) {
-          mockResponses.push(Promise.resolve(mockResponse));
+          const activeResponse = createUploadActiveResponse();
+          activeResponses.push(activeResponse);
+          mockResponses.push(Promise.resolve(activeResponse));
         }
         mockResponses.push(
           Promise.resolve(
@@ -138,6 +142,9 @@ describe('File', () => {
 
         await client.files.upload({file: filePath});
         expect(fetchSpy).toHaveBeenCalledTimes(numRequests + 1);
+        expect(
+          activeResponses.every((response) => response.bodyUsed),
+        ).toBeTrue();
 
         const allArgs = fetchSpy.calls.allArgs();
 
@@ -180,11 +187,18 @@ describe('File', () => {
         // of the requests to upload the file.
         const mockResponses = [
           Promise.resolve(new Response('', createUrlOkoptions)),
-          Promise.resolve(new Response('', uploadMissingStatusOptions)),
         ];
+        const missingStatusResponse = new Response(
+          '',
+          uploadMissingStatusOptions,
+        );
+        mockResponses.push(Promise.resolve(missingStatusResponse));
+        const activeResponses = [];
 
         for (let i = 0; i < numRequests - 1; i++) {
-          mockResponses.push(Promise.resolve(mockResponse));
+          const activeResponse = createUploadActiveResponse();
+          activeResponses.push(activeResponse);
+          mockResponses.push(Promise.resolve(activeResponse));
         }
         mockResponses.push(
           Promise.resolve(
@@ -205,6 +219,10 @@ describe('File', () => {
         // 1 initial request to get the upload url, 1 response missing x-goog-upload-status header and then the rest
         // of the requests to upload the file.
         expect(fetchSpy).toHaveBeenCalledTimes(numRequests + 1 + 1);
+        expect(missingStatusResponse.bodyUsed).toBeTrue();
+        expect(
+          activeResponses.every((response) => response.bodyUsed),
+        ).toBeTrue();
 
         const allArgs = fetchSpy.calls.allArgs();
 
@@ -241,9 +259,12 @@ describe('File', () => {
         const mockResponses = [
           Promise.resolve(new Response('', createUrlOkoptions)),
         ];
+        const activeResponses = [];
 
         for (let i = 0; i < numRequests - 1; i++) {
-          mockResponses.push(Promise.resolve(mockResponse));
+          const activeResponse = createUploadActiveResponse();
+          activeResponses.push(activeResponse);
+          mockResponses.push(Promise.resolve(activeResponse));
         }
         mockResponses.push(
           Promise.resolve(
@@ -263,6 +284,9 @@ describe('File', () => {
         await client.files.upload({file: testBlob});
 
         expect(fetchSpy).toHaveBeenCalledTimes(numRequests + 1);
+        expect(
+          activeResponses.every((response) => response.bodyUsed),
+        ).toBeTrue();
         const allArgs = fetchSpy.calls.allArgs();
 
         // make sure we get the correct create url. mimeType and fileSize in the
@@ -304,11 +328,18 @@ describe('File', () => {
         // of the requests to upload the file.
         const mockResponses = [
           Promise.resolve(new Response('', createUrlOkoptions)),
-          Promise.resolve(new Response('', uploadMissingStatusOptions)),
         ];
+        const missingStatusResponse = new Response(
+          '',
+          uploadMissingStatusOptions,
+        );
+        mockResponses.push(Promise.resolve(missingStatusResponse));
+        const activeResponses = [];
 
         for (let i = 0; i < numRequests - 1; i++) {
-          mockResponses.push(Promise.resolve(mockResponse));
+          const activeResponse = createUploadActiveResponse();
+          activeResponses.push(activeResponse);
+          mockResponses.push(Promise.resolve(activeResponse));
         }
         mockResponses.push(
           Promise.resolve(
@@ -329,6 +360,10 @@ describe('File', () => {
 
         // 1 initial request to get the upload url, 1 response missing x-goog-upload-status header and then the rest
         expect(fetchSpy).toHaveBeenCalledTimes(numRequests + 1 + 1);
+        expect(missingStatusResponse.bodyUsed).toBeTrue();
+        expect(
+          activeResponses.every((response) => response.bodyUsed),
+        ).toBeTrue();
         const allArgs = fetchSpy.calls.allArgs();
 
         // make sure we get the correct create url. mimeType and fileSize in the


### PR DESCRIPTION
Fixes #1278.

## Summary
- cancel intermediate resumable upload response bodies when the upload status is missing and the client retries
- cancel successful intermediate `active` upload response bodies before sending the next chunk
- keep the final response body intact so callers can still parse the final JSON payload
- cover both Node path uploads and Blob uploads in file upload unit tests

## Verification
- `npx eslint src/cross/_cross_uploader.ts src/node/_node_uploader.ts test/unit/file_test.ts`
- `npm run unit-test -- --filter=File`

The issue reproduction reports Deno leak detection for unconsumed fetch response bodies. This patch ensures the SDK cancels upload responses it does not otherwise read.
