### PR TITLE
fix: cancel intermediate upload response bodies

### DIFF
--- a/src/cross/_cross_uploader.ts
+++ b/src/cross/_cross_uploader.ts
@@ -20,6 +20,16 @@ export const INITIAL_RETRY_DELAY_MS = 1000;
 export const DELAY_MULTIPLIER = 2;
 export const X_GOOG_UPLOAD_STATUS_HEADER_FIELD = 'x-goog-upload-status';
 
+export async function discardResponseBody(
+  response?: HttpResponse,
+): Promise<void> {
+  const body = response?.responseInternal?.body;
+  if (!body) {
+    return;
+  }
+  await body.cancel();
+}
+
 export class CrossUploader implements Uploader {
   async upload(
     file: string | Blob,
@@ -170,6 +180,7 @@ async function uploadBlobInternal(
     if (response?.headers?.[X_GOOG_UPLOAD_STATUS_HEADER_FIELD] !== 'active') {
       break;
     }
+    await discardResponseBody(response);
     // TODO(b/401391430) Investigate why the upload status is not finalized
     // even though all content has been uploaded.
     if (fileSize <= offset) {

--- a/src/node/_node_uploader.ts
+++ b/src/node/_node_uploader.ts
@@ -15,6 +15,7 @@ import {
   MAX_CHUNK_SIZE,
   MAX_RETRY_COUNT,
   X_GOOG_UPLOAD_STATUS_HEADER_FIELD,
+  discardResponseBody,
   getBlobStat,
   sleep,
   uploadBlob,
@@ -313,6 +314,7 @@ export class NodeUploader implements Uploader {
         ) {
           break;
         }
+        await discardResponseBody(response);
         if (fileSize <= offset) {
           throw new Error(
             'All content has been uploaded, but the upload status is not finalized.',

--- a/test/unit/node/node_upload_test.ts
+++ b/test/unit/node/node_upload_test.ts
@@ -32,12 +32,19 @@ const lastCorrectFetchOkOptions = {
   },
   url: 'some-url',
 };
-const mockResponse = new Response(
-  JSON.stringify({
-    data: 'data1',
-  }),
-  fetchOkOptions,
-);
+function createActiveUploadResponse(onCancel?: () => void): Response {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"data":"data1"}'));
+      },
+      cancel() {
+        onCancel?.();
+      },
+    }),
+    fetchOkOptions,
+  );
+}
 
 describe('Node uploader', () => {
   let originalGeminiBaseUrl: string | undefined;
@@ -82,8 +89,11 @@ describe('Node uploader', () => {
       const numRequests = Math.ceil(TEST_FILE_SIZE / DEFAULT_CHUNK_SIZE);
 
       const mockResponses = [];
+      let cancelCount = 0;
       for (let i = 0; i < numRequests - 1; i++) {
-        mockResponses.push(Promise.resolve(mockResponse));
+        mockResponses.push(
+          Promise.resolve(createActiveUploadResponse(() => cancelCount++)),
+        );
       }
       mockResponses.push(
         Promise.resolve(
@@ -106,6 +116,7 @@ describe('Node uploader', () => {
 
       await uploader.upload(filePath, TEST_UPLOAD_URL, client['apiClient']);
       expect(fetchSpy).toHaveBeenCalledTimes(numRequests);
+      expect(cancelCount).toBe(numRequests - 1);
       const allArgs = fetchSpy.calls.allArgs();
       let byteProcessed = 0;
 
@@ -128,8 +139,11 @@ describe('Node uploader', () => {
     const numRequests = Math.ceil(TEST_FILE_SIZE / DEFAULT_CHUNK_SIZE);
 
     const mockResponses = [];
+    let cancelCount = 0;
     for (let i = 0; i < numRequests - 1; i++) {
-      mockResponses.push(Promise.resolve(mockResponse));
+      mockResponses.push(
+        Promise.resolve(createActiveUploadResponse(() => cancelCount++)),
+      );
     }
     mockResponses.push(
       Promise.resolve(
@@ -155,6 +169,7 @@ describe('Node uploader', () => {
       customHttpOptions,
     );
     expect(fetchSpy).toHaveBeenCalledTimes(numRequests);
+    expect(cancelCount).toBe(numRequests - 1);
     const allArgs = fetchSpy.calls.allArgs();
     const rewrittenUrl = allArgs[0][0] as string;
     expect(rewrittenUrl).toContain(
@@ -182,8 +197,11 @@ describe('Node uploader', () => {
       const numRequests = Math.ceil(TEST_FILE_SIZE / DEFAULT_CHUNK_SIZE);
 
       const mockResponses = [];
+      let cancelCount = 0;
       for (let i = 0; i < numRequests - 1; i++) {
-        mockResponses.push(Promise.resolve(mockResponse));
+        mockResponses.push(
+          Promise.resolve(createActiveUploadResponse(() => cancelCount++)),
+        );
       }
       mockResponses.push(
         Promise.resolve(
@@ -205,6 +223,7 @@ describe('Node uploader', () => {
       }
       await uploader.upload(testBlob, TEST_UPLOAD_URL, client['apiClient']);
       expect(fetchSpy).toHaveBeenCalledTimes(numRequests);
+      expect(cancelCount).toBe(numRequests - 1);
       const allArgs = fetchSpy.calls.allArgs();
       let byteProcessed = 0;
       for (let i = 0; i < numRequests; i++) {


### PR DESCRIPTION
Fixes #1278.

## What changed
- Cancel intermediate resumable-upload response bodies when the upload status is `active`.
- Apply the same cleanup to Blob uploads and Node path uploads.
- Add uploader unit coverage that verifies intermediate active responses are cancelled while the final response remains available for JSON parsing.

## Verification
- `npm run lint -- src/cross/_cross_uploader.ts src/node/_node_uploader.ts test/unit/node/node_upload_test.ts`
- `npx jasmine dist/test/unit/node/node_upload_test.js --filter='Node uploader'`

## Notes
- I also ran `npm audit --audit-level=high --omit=dev`; the existing dependency tree reports unrelated high/critical advisories (`minimatch`, `protobufjs`). This PR is intentionally scoped to the Deno leaked response body issue.