### PR TITLE
fix: generate valid auth token field masks

### DIFF
--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -11,7 +11,15 @@ import * as converters from './converters/_tokens_converters.js';
 import * as types from './types.js';
 
 /**
- * Returns a comma-separated list of field masks from a given object.
+ * Converts a lowerCamelCase field path to the proto snake_case field path used
+ * by FieldMask.
+ */
+function toProtoFieldPath(field: string): string {
+  return field.replace(/[A-Z]/g, (char) => `_${char.toLowerCase()}`);
+}
+
+/**
+ * Returns a comma-separated list of top-level field masks from a given object.
  *
  * @param setup The object to extract field masks from.
  * @return A comma-separated list of field masks.
@@ -21,18 +29,7 @@ function getFieldMasks(setup: Record<string, unknown>): string {
 
   for (const key in setup) {
     if (Object.prototype.hasOwnProperty.call(setup, key)) {
-      const value = setup[key];
-      // 2nd layer, recursively get field masks see TODO(b/418290100)
-      if (
-        typeof value === 'object' &&
-        value != null &&
-        Object.keys(value).length > 0
-      ) {
-        const field = Object.keys(value).map((kk) => `${key}.${kk}`);
-        fields.push(...field);
-      } else {
-        fields.push(key); // 1st layer
-      }
+      fields.push(toProtoFieldPath(key));
     }
   }
 
@@ -119,10 +116,10 @@ function convertBidiSetupToTokenSetup(
       if (preExistingFieldMask.length > 0) {
         mappedFieldsFromPreExisting = preExistingFieldMask.map((field) => {
           if (generationConfigFields.includes(field)) {
-            return `generationConfig.${field}`;
+            return `generation_config.${toProtoFieldPath(field)}`;
           }
-          return field; // Keep original field name if not in
-          // generationConfigFields
+          return toProtoFieldPath(field); // Keep original field path if not in
+          // generationConfigFields.
         });
       }
 

--- a/test/unit/tokens_test.ts
+++ b/test/unit/tokens_test.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {ApiClient, HttpRequest} from '../../src/_api_client.js';
+import {CrossDownloader} from '../../src/cross/_cross_downloader.js';
+import {CrossUploader} from '../../src/cross/_cross_uploader.js';
+import {Tokens} from '../../src/tokens.js';
+import * as types from '../../src/types.js';
+import {FakeAuth} from '../_fake_auth.js';
+
+function createTokens(): {tokens: Tokens; requestSpy: jasmine.Spy} {
+  const apiClient = new ApiClient({
+    auth: new FakeAuth(),
+    apiKey: 'test-api-key',
+    uploader: new CrossUploader(),
+    downloader: new CrossDownloader(),
+  });
+  const requestSpy = spyOn(apiClient, 'request').and.callFake(
+    async (_request: HttpRequest) =>
+      new types.HttpResponse(new Response(JSON.stringify({name: 'token'}))),
+  );
+  return {tokens: new Tokens(apiClient), requestSpy};
+}
+
+describe('tokens', () => {
+  it('generates top-level proto field mask paths for live constraints', async () => {
+    const {tokens, requestSpy} = createTokens();
+
+    await tokens.create({
+      config: {
+        uses: 1,
+        liveConnectConstraints: {
+          model: 'gemini-2.0-flash-live-001',
+          config: {
+            responseModalities: [types.Modality.AUDIO],
+            systemInstruction: 'You are a helpful assistant.',
+            tools: [{functionDeclarations: [{name: 'test_fn'}]}],
+            inputAudioTranscription: {},
+            outputAudioTranscription: {},
+            sessionResumption: {},
+          },
+        },
+        lockAdditionalFields: [],
+      },
+    });
+
+    const body = JSON.parse(requestSpy.calls.mostRecent().args[0].body);
+    const fieldMask = body.fieldMask.split(',');
+
+    expect(fieldMask).toContain('model');
+    expect(fieldMask).toContain('generation_config');
+    expect(fieldMask).toContain('system_instruction');
+    expect(fieldMask).toContain('tools');
+    expect(fieldMask).toContain('input_audio_transcription');
+    expect(fieldMask).toContain('output_audio_transcription');
+    expect(fieldMask).toContain('session_resumption');
+    expect(fieldMask).not.toContain('tools.0');
+    expect(fieldMask).not.toContain('system_instruction.parts');
+    expect(fieldMask).not.toContain('generation_config.response_modalities');
+  });
+
+  it('maps additional generation config fields to proto field paths', async () => {
+    const {tokens, requestSpy} = createTokens();
+
+    await tokens.create({
+      config: {
+        liveConnectConstraints: {
+          model: 'gemini-2.0-flash-live-001',
+          config: {
+            responseModalities: [types.Modality.AUDIO],
+          },
+        },
+        lockAdditionalFields: ['temperature', 'topK', 'systemInstruction'],
+      },
+    });
+
+    const body = JSON.parse(requestSpy.calls.mostRecent().args[0].body);
+    const fieldMask = body.fieldMask.split(',');
+
+    expect(fieldMask).toContain('generation_config');
+    expect(fieldMask).toContain('generation_config.temperature');
+    expect(fieldMask).toContain('generation_config.top_k');
+    expect(fieldMask).toContain('system_instruction');
+    expect(fieldMask).not.toContain('generationConfig.temperature');
+    expect(fieldMask).not.toContain('generationConfig.topK');
+  });
+});


### PR DESCRIPTION
Fixes #1492.\n\n## Summary\n- generate top-level proto field mask paths for Live auth token constraints\n- avoid invalid nested paths such as tools.0 and system_instruction.parts\n- map additional generation config locks to proto field paths such as generation_config.top_k\n- add unit coverage through authTokens.create request body generation\n\n## Tests\n- npm run unit-test -- --filter=tokens\n- npx prettier src/tokens.ts test/unit/tokens_test.ts --check\n- npx eslint src/tokens.ts test/unit/tokens_test.ts\n- git diff --check