### PR TITLE
fix: remove preinstall no-op script

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     }
   },
   "scripts": {
-    "preinstall": "echo 'preinstall: no-op'",
     "prepare": "node scripts/prepare.js",
     "prepack": "echo 'prepack: no-op'",
     "postpack": "echo 'postpack: no-op'",


### PR DESCRIPTION
Removed no-op preinstall script from package.json.

This will stop package managers like `pnpm` prompting to allow running of the script, which users may allow without checking the necessity of, creating unnecessary risk.

Closes #1701, Supersedes #1690